### PR TITLE
Update java version for SDKMAN

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -16,5 +16,5 @@ Code is in the `code` folder and solutions are in the `solution`s subfolders, do
 - install jbang and JDK 19
 - https://www.jbang.dev/documentation/guide/latest/installation.html
 - `sdk install jbang`
-- `sdk install java 19.ea.31`
+- `sdk install java 19.ea.31-open`
 - `git clone git@github.com:strehler/workshop-jbcn.git`


### PR DESCRIPTION
Trying without the `-open` sufix yields:
```bash
$ sdk install java 19.ea.31
Stop! java 19.ea.31 is not available. Possible causes:
 * 19.ea.31 is an invalid version
 * java binaries are incompatible with your platform
 * java has not been released yet

Tip: see all available versions for your platform:
```
(tried in Linux)